### PR TITLE
Handle case where large file changed in earlier commit

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,31 +38,31 @@ function buildHeader(fileA, fileB) {
 }
 
 function buildContent(github, owner, repo, base, head, file) {
-  const {filename, patch, status} = file;
+  const {filename, patch, status, sha} = file;
 
   // Get the content for the files
   switch (status) {
     case 'removed':
-      return getContent(github, owner, repo, filename, base).then(content => {
+      return getContent(github, owner, repo, filename, base, sha).then(content => {
         return {filename, patch, status, header: buildHeader(filename, filename), fileA: atob(content)};
       });
 
     case 'added':
-      return getContent(github, owner, repo, filename, head).then(content => {
+      return getContent(github, owner, repo, filename, head, sha).then(content => {
         return {filename, patch, status, header: buildHeader(filename, filename), fileB: atob(content)};
       });
 
     case 'modified':
       return Promise.all([
-          getContent(github, owner, repo, filename, base),
-          getContent(github, owner, repo, filename, head),
+          getContent(github, owner, repo, filename, base, sha),
+          getContent(github, owner, repo, filename, head, sha),
       ]).then(files => {
         const [fileA, fileB] = files;
         return {filename, patch, status, header: buildHeader(filename, filename), fileA: atob(fileA), fileB: atob(fileB)};
       });
 
     case 'renamed':
-      return getContent(github, owner, repo, filename, head).then(content => {
+      return getContent(github, owner, repo, filename, head, sha).then(content => {
         const decodedFile = atob(content);
         const previousFilename = file.previous_filename;
         const header = buildHeader(filename, previousFilename);
@@ -77,7 +77,7 @@ function buildContent(github, owner, repo, base, head, file) {
   }
 }
 
-function getContent(github, owner, repo, path, commit) {
+function getContent(github, owner, repo, path, commit, commitSha) {
   return github.repos.getContent({
     owner,
     repo,
@@ -94,7 +94,10 @@ function getContent(github, owner, repo, path, commit) {
           repo,
           sha: commit
         })
-        .then(commit => commit.files.find(file => file.filename === path).sha)
+        .then(commit => {
+          const file = commit.files.find(file => file.filename === path)
+          return file ? file.sha : commitSha
+        })
         .then(sha => github.gitdata.getBlob({
           owner,
           repo,


### PR DESCRIPTION
So sorry @alex-e-leon, I came across another edge case [I'd introduced](https://github.com/alex-e-leon/github-diff/pull/5) when

- a particular large file has changed in commits between base and head
- head did not include that large file as part of the commit

In this case, that large file will not be found in the particular commit that is looked up resulting in an error

> Cannot read property 'sha' of undefined

To address this, I've reintroduced passing around the sha of every file that is retrieved by `compareCommits` and used that as a fallback if the particular commit for comparison does not include that file.

Let me know your thoughts on this.

**Test case**: _(note commit at 1.3.0 of my sample repo does not include a change on the zip)_

```
githubDiff('lyuzashi/github-diff-sample', '1.1.0', '1.3.0')
> [ { filename: 'binary-data.zip',
    patch: undefined,
    status: 'modified',
    header: 'diff --git a/binary-data.zip b/binary-data.zip\n--- a/binary-data.zip\n+++ b/binary-data.zip\n',
    fileA: <Buffer 50 4b 03 04 14 00 08 00 08 00 00 65 95 4b 00 00 00 00 00 00 00 00 00 00 00 00 18 00 10 00 70 65 78 65 6c 73 2d 70 68 6f 74 6f 2d 34 35 31 34 39 30 2e ... >,
    fileB: <Buffer 50 4b 03 04 14 00 08 00 08 00 03 65 95 4b 00 00 00 00 00 00 00 00 00 00 00 00 18 00 10 00 70 65 78 65 6c 73 2d 70 68 6f 74 6f 2d 32 34 36 35 31 39 2e ... > },
  { filename: 'readme.MD',
    patch: '@@ -7,6 +7,6 @@ This repository is a quick test for the following functions of [github-diff](htt\n * Modifying files\n * Renaming files\n \n-This file was modified.\n+This file was modified again.\n \n binary-data.zip was added.',
    status: 'modified',
    header: 'diff --git a/readme.MD b/readme.MD\n--- a/readme.MD\n+++ b/readme.MD\n',
    fileA: '# Sample Repository for GitHub Diff\n\nThis repository is a quick test for the following functions of [github-diff](https://github.com/alex-e-leon/github-diff)\n\n* Removing files\n* Adding files\n* Modifying files\n* Renaming files\n\nThis file was modified.\n\nbinary-data.zip was added.\n',
    fileB: '# Sample Repository for GitHub Diff\n\nThis repository is a quick test for the following functions of [github-diff](https://github.com/alex-e-leon/github-diff)\n\n* Removing files\n* Adding files\n* Modifying files\n* Renaming files\n\nThis file was modified again.\n\nbinary-data.zip was added.\n' } ]
```

Really hoping to eventually find time to write some unit tests for all these cases.