### PR TITLE
Switched from getCommit to getTree for large file handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,12 +89,12 @@ function getContent(github, owner, repo, path, commit) {
     try {
       const apiError = JSON.parse(err);
       if (apiError.errors.find(error => error.code === 'too_large')) {
-        return github.repos.getCommit({
+        return github.gitdata.getTree({
           owner,
           repo,
           sha: commit
         })
-        .then(commit => commit.files.find(file => file.filename === path).sha)
+        .then(commit => commit.tree.find(file => file.path === path).sha)
         .then(sha => github.gitdata.getBlob({
           owner,
           repo,


### PR DESCRIPTION
Calling getCommit doesn't work if the file hasn't changed in both commits, but getTree does.

See https://github.com/alex-e-leon/github-diff/pull/6 for more information about the issue