### PR TITLE
Allow blob get of deep tree data

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,7 @@ function getContent(github, owner, repo, path, commit) {
         return github.gitdata.getTree({
           owner,
           repo,
+          recursive: true,
           sha: commit
         })
         .then(commit => commit.tree.find(file => file.path === path).sha)

--- a/index.js
+++ b/index.js
@@ -92,6 +92,9 @@ function getContent(github, owner, repo, path, commit) {
         return github.gitdata.getTree({
           owner,
           repo,
+          // May hit githubs maximum limit if the tree is too large
+          // we could handle larger trees if we recursively fetched subtrees.
+          // see https://developer.github.com/v3/git/trees/#get-a-tree-recursively
           recursive: true,
           sha: commit
         })


### PR DESCRIPTION
Hi @alex-e-leon! I had a chance to try out the [getTree solution](https://github.com/alex-e-leon/github-diff/pull/7) on a real-world repo and encountered a little issue.

Turns out by default `getTree` only returns a shallow tree, and the large file I was attempting to include in the diff is buried a few directories deep.

Easy fix (so long as this doesn't run into the "maximum limit" and get truncated) using the [recursive option](https://developer.github.com/v3/git/trees/#get-a-tree-recursively).