### PR TITLE
Combine modified and renamed behaviour to allow for modified + renamed

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,11 @@ function buildContent(github, owner, repo, base, head, file) {
       ]).then(files => {
         const [fileA, fileB] = files;
         const header = buildHeader(previousFilename, filename);
-        return {previousFilename, filename, patch, status, header, fileA: atob(fileA), fileB: atob(fileB)};
+        const result = {filename, patch, status, header, fileA: atob(fileA), fileB: atob(fileB)};
+        if (status === 'renamed') {
+          result.previousFilename = previousFilename;
+        }
+        return result;
       });
 
     default:


### PR DESCRIPTION
If a file was both modified and renamed between the two versions, then 
it was treated as just a rename.
Whilst the patch contents would still be correct, only the contents of 
fileB would be downloaded (presumably as an optimisation, since in a 
pure rename the contents would be identical), and were used for both 
fileA and fileB.

This would mean that when comparing fileA and fileB in the case of a 
rename + modify, that the modification would be lost.

This unifies the logic for modify and rename, but handles the differing 
filenames in the rename case.
It has the cost of an extra getContent request for pure renames.